### PR TITLE
Fix improper null check in class-property-info

### DIFF
--- a/gobject/gobject.base.lisp
+++ b/gobject/gobject.base.lisp
@@ -647,8 +647,8 @@
 
 (defun class-property-info (type property-name)
   (with-unwind (class (g-type-class-ref type) g-type-class-unref)
-    (let* ((param-spec (g-object-class-find-property class property-name)))
-      (when param-spec
+    (let ((param-spec (g-object-class-find-property class property-name)))
+      (when (and param-spec (not (cffi:null-pointer-p param-spec)))
         (parse-g-param-spec param-spec)))))
 
 ;;; ----------------------------------------------------------------------------


### PR DESCRIPTION
Per @PuercoPop checking for both nil and null-pointer is necessary