### PR TITLE
Add GtkBuilder demo, better handler lookup.

### DIFF
--- a/demo/gtk-demo/builder.lisp
+++ b/demo/gtk-demo/builder.lisp
@@ -1,0 +1,44 @@
+;;;; Glade and GtkBuilder
+
+(in-package #:gtk-demo)
+
+(defvar *xml*
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <object class=\"GtkWindow\" id=\"window\">
+    <property name=\"can_focus\">False</property>
+    <signal name=\"destroy\" handler=\"destroy\" swapped=\"no\"/>
+    <child>
+      <object class=\"GtkButton\" id=\"button\">
+        <property name=\"label\" translatable=\"yes\">button</property>
+        <property name=\"use_action_appearance\">False</property>
+        <property name=\"visible\">True</property>
+        <property name=\"can_focus\">True</property>
+        <property name=\"receives_default\">True</property>
+        <property name=\"use_action_appearance\">False</property>
+        <signal name=\"pressed\" handler=\"pressed\" swapped=\"no\"/>
+      </object>
+    </child>
+  </object>
+</interface>")
+
+(defun destroy (widget)
+  (declare (ignore widget))
+  (leave-gtk-main))
+
+(defun pressed (widget)
+  (declare (ignore widget))
+  (let ((dialog (make-instance 'gtk-message-dialog
+                               :message-type :info
+                               :buttons :ok
+                               :text "Hello, World!")))
+    (gtk-dialog-run dialog)
+    (gtk-widget-destroy dialog)))
+
+(defun example-builder ()
+  (within-main-loop
+    (let ((builder (make-instance 'gtk-builder :from-string *xml*)))
+      (let ((*package* #.(find-package '#:gtk-demo)))
+        (gtk-builder-connect-signals-auto builder))
+      (gtk-widget-show-all (gtk-builder-get-object builder "window")))))

--- a/demo/gtk-demo/builder.lisp
+++ b/demo/gtk-demo/builder.lisp
@@ -2,27 +2,6 @@
 
 (in-package #:gtk-demo)
 
-(defvar *xml*
-  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<interface>
-  <!-- interface-requires gtk+ 3.0 -->
-  <object class=\"GtkWindow\" id=\"window\">
-    <property name=\"can_focus\">False</property>
-    <signal name=\"destroy\" handler=\"destroy\" swapped=\"no\"/>
-    <child>
-      <object class=\"GtkButton\" id=\"button\">
-        <property name=\"label\" translatable=\"yes\">button</property>
-        <property name=\"use_action_appearance\">False</property>
-        <property name=\"visible\">True</property>
-        <property name=\"can_focus\">True</property>
-        <property name=\"receives_default\">True</property>
-        <property name=\"use_action_appearance\">False</property>
-        <signal name=\"pressed\" handler=\"pressed\" swapped=\"no\"/>
-      </object>
-    </child>
-  </object>
-</interface>")
-
 (defun destroy (widget)
   (declare (ignore widget))
   (leave-gtk-main))
@@ -38,7 +17,6 @@
 
 (defun example-builder ()
   (within-main-loop
-    (let ((builder (make-instance 'gtk-builder :from-string *xml*)))
-      (let ((*package* #.(find-package '#:gtk-demo)))
-        (gtk-builder-connect-signals-auto builder))
+    (let ((builder (make-instance 'gtk-builder :from-file (rel-path "builder.ui"))))
+      (gtk-builder-connect-signals-auto builder #.(find-package '#:gtk-demo))
       (gtk-widget-show-all (gtk-builder-get-object builder "window")))))

--- a/demo/gtk-demo/builder.ui
+++ b/demo/gtk-demo/builder.ui
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <object class="GtkWindow" id="window">
+    <property name="can_focus">False</property>
+    <signal name="destroy" handler="destroy" swapped="no"/>
+    <child>
+      <object class="GtkButton" id="button">
+        <property name="label" translatable="yes">button</property>
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <property name="use_action_appearance">False</property>
+        <signal name="pressed" handler="pressed" swapped="no"/>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/demo/gtk-demo/cl-cffi-gtk-demo-gtk.asd
+++ b/demo/gtk-demo/cl-cffi-gtk-demo-gtk.asd
@@ -46,6 +46,7 @@
                (:file "assistant")
                (:file "box")
                (:file "box-packing")
+               (:file "builder")
                (:file "button")
                (:file "button-box")
                (:file "buttons")

--- a/demo/gtk-demo/gtk-demo.lisp
+++ b/demo/gtk-demo/gtk-demo.lisp
@@ -175,7 +175,8 @@
           (demo parent 5 "Popover Demo" "popover.lisp" 'popover-demo)
           (demo parent 6 "Custom Subclass" "subclass-window.lisp" 'custom-window-demo)
           (demo parent 7 "Simple Drag And Drop" "simple-drag-and-drop.lisp" 'demo-simple-drag-and-drop)
-          (demo parent 8 "Drag And Drop" "drag-and-drop.lisp" 'demo-drag-and-drop))))
+          (demo parent 8 "Drag And Drop" "drag-and-drop.lisp" 'demo-drag-and-drop)
+          (demo parent 9 "Glade and GtkBuilder" "builder.lisp" 'example-builder))))
     model))
 
 (defun create-view-and-model ()

--- a/gtk/gtk.builder.lisp
+++ b/gtk/gtk.builder.lisp
@@ -753,7 +753,8 @@ Example 9. A GtkBuilder UI Definition
   @code{G_FILE_ERROR domain}.
 
   Since 2.12"
-  (%gtk-builder-add-from-file builder filename (null-pointer)))
+  (with-g-error (err)
+    (%gtk-builder-add-from-file builder filename err)))
 
 (export 'gtk-builder-add-from-file)
 
@@ -812,7 +813,8 @@ Example 9. A GtkBuilder UI Definition
   from the @code{GTK_BUILDER_ERROR} or @code{G_MARKUP_ERROR domain}.
 
   Since 2.12"
-  (%gtk-builder-add-from-string builder buffer -1 (null-pointer)))
+  (with-g-error (err)
+    (%gtk-builder-add-from-string builder buffer -1 err)))
 
 (export 'gtk-builder-add-from-string)
 
@@ -855,7 +857,8 @@ Example 9. A GtkBuilder UI Definition
        for object-id in object-ids
        do (setf (mem-aref l :pointer i) (foreign-string-alloc object-id)))
     (unwind-protect
-         (%gtk-builder-add-objects-from-file builder filename l (null-pointer))
+         (with-g-error (err)
+           (%gtk-builder-add-objects-from-file builder filename l err))
       (loop
          for i from 0
          repeat (1- (length object-ids))
@@ -904,11 +907,8 @@ Example 9. A GtkBuilder UI Definition
        for object-id in object-ids
        do (setf (mem-aref l :pointer i) (foreign-string-alloc object-id)))
     (unwind-protect
-      (%gtk-builder-add-objects-from-string builder
-                                            buffer
-                                            -1
-                                            l
-                                            (null-pointer))
+         (with-g-error (err)
+           (%gtk-builder-add-objects-from-string builder buffer -1 l err))
       (loop
          for i from 0
          repeat (1- (length object-ids))
@@ -1066,10 +1066,12 @@ Example 9. A GtkBuilder UI Definition
 
 (export 'gtk-builder-connect-signals)
 
-(defun gtk-builder-connect-signals-auto (builder)
+(defun gtk-builder-connect-signals-auto (builder &optional (package *package*))
  #+cl-cffi-gtk-documentation
  "@version{2013-5-28}
   @argument[builder]{a @class{gtk-builder} object}
+  @argument[package]{the package in which symbols are read, @sym{*package*}
+    by default}
   @begin{short}
     This method is a simpler variation of the function
     @fun{gtk-builder-connect-signals-full}.
@@ -1079,7 +1081,8 @@ Example 9. A GtkBuilder UI Definition
   function can only be called once, subsequent calls will do nothing.
 
   Note that handler names are looked up via @fun{read-from-string} in the
-  current package, therefore supplying a package prefix might be necessary.
+  current package by default, therefore supplying a package prefix via the
+  @arg{package} parameter might be necessary.
 
   Since 2.12"
   (flet ((connect-func (builder
@@ -1089,7 +1092,9 @@ Example 9. A GtkBuilder UI Definition
                         connect-object
                         flags)
            (declare (ignore builder connect-object))
-           (let ((handler (fdefinition (read-from-string handler-name))))
+           (let ((handler (fdefinition (let ((*package* package)
+                                             (*read-eval* NIL))
+                                         (read-from-string handler-name)))))
              (when handler
                (g-signal-connect object
                                  signal-name


### PR DESCRIPTION
Like it says. No renaming due to possible users, even though the one with `-AUTO` will be likely much more easy to use.

Question: Should we have an `&OPTIONAL (PACKAGE *PACKAGE)` parameter to make it more succinct?

Also http://python-gtk-3-tutorial.readthedocs.io/en/latest/builder.html does it with a dictionary too, so the existing function is fine from that point of view, possibly it's worth just doing it via keyword arguments though.

@svillemot