### PR TITLE
gio.file.lisp: Add g-file-new-for-uri

### DIFF
--- a/gio/gio.file.lisp
+++ b/gio/gio.file.lisp
@@ -1127,6 +1127,12 @@
 ;;;
 ;;; Returns :
 ;;;     a new GFile. Free the returned object with g_object_unref(). [transfer full]
+
+(defcfun g-file-new-for-uri (g-object g-file)
+  (uri :string))
+
+(export 'g-file-new-for-uri)
+
 ;;; g_file_new_tmp ()
 ;;;
 ;;; GFile *             g_file_new_tmp                      (const char *tmpl,


### PR DESCRIPTION
I noticed that g-file-new-for-uri was missing when trying to do Drag-And-Drop of file URI's.