### PR TITLE
Add a missing enumeration for TLS connections.

### DIFF
--- a/gio/cl-cffi-gtk-gio.asd
+++ b/gio/cl-cffi-gtk-gio.asd
@@ -36,6 +36,7 @@
    (:file "gio.init")
    ;; File Operations
    (:file "gio.file")                ; File and Directory Handling
+   (:file "gio.tls-connection")
    ;; Application information and launch contexts
    (:file "gio.content-type")        ; Platform-specific content typing
    (:file "gio.app-info")            ; Application information, launch contexts

--- a/gio/gio.tls-connection.lisp
+++ b/gio/gio.tls-connection.lisp
@@ -1,0 +1,13 @@
+(in-package :gio)
+
+(define-g-flags "GTlsCertificateFlags" g-tls-certificate-flags
+  (:export t
+   :type-initializer "g_tls_certificate_flags_get_type")
+  (:unknown-ca 1)
+  (:bad-identity 2)
+  (:not-activated 4)
+  (:expired 8)
+  (:revoked 16)
+  (:insecure 32)
+  (:generic-error 64)
+  (:validate-all 128))


### PR DESCRIPTION
Fixes <https://github.com/Ferada/cl-cffi-gtk/issues/37>.